### PR TITLE
contain jQuery UI styles to #mc_signup context

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1,9 +1,10 @@
-.error_msg { 
+#mc_signup .error_msg { 
 	color: red;
 	margin: 0px;
 	font-weight: bold;
 }
-.success_msg { 
+
+#mc_signup .success_msg { 
 	color: green; 
 	margin: 0px;
 	font-weight: bold;

--- a/css/flick/flick.css
+++ b/css/flick/flick.css
@@ -10,35 +10,35 @@
 
 /* Layout helpers
 ----------------------------------*/
-.ui-helper-hidden { display: none; }
-.ui-helper-hidden-accessible { position: absolute !important; clip: rect(1px 1px 1px 1px); clip: rect(1px,1px,1px,1px); }
-.ui-helper-reset { margin: 0; padding: 0; border: 0; outline: 0; line-height: 1.3; text-decoration: none; font-size: 100%; list-style: none; }
-.ui-helper-clearfix:after { content: "."; display: block; height: 0; clear: both; visibility: hidden; }
-.ui-helper-clearfix { display: inline-block; }
+#mc_signup .ui-helper-hidden { display: none; }
+#mc_signup .ui-helper-hidden-accessible { position: absolute !important; clip: rect(1px 1px 1px 1px); clip: rect(1px,1px,1px,1px); }
+#mc_signup .ui-helper-reset { margin: 0; padding: 0; border: 0; outline: 0; line-height: 1.3; text-decoration: none; font-size: 100%; list-style: none; }
+#mc_signup .ui-helper-clearfix:after { content: "."; display: block; height: 0; clear: both; visibility: hidden; }
+#mc_signup .ui-helper-clearfix { display: inline-block; }
 /* required comment for clearfix to work in Opera \*/
-* html .ui-helper-clearfix { height:1%; }
-.ui-helper-clearfix { display:block; }
+* html #mc_signup .ui-helper-clearfix { height:1%; }
+#mc_signup .ui-helper-clearfix { display:block; }
 /* end clearfix */
-.ui-helper-zfix { width: 100%; height: 100%; top: 0; left: 0; position: absolute; opacity: 0; filter:Alpha(Opacity=0); }
+#mc_signup .ui-helper-zfix { width: 100%; height: 100%; top: 0; left: 0; position: absolute; opacity: 0; filter:Alpha(Opacity=0); }
 
 
 /* Interaction Cues
 ----------------------------------*/
-.ui-state-disabled { cursor: default !important; }
+#mc_signup .ui-state-disabled { cursor: default !important; }
 
 
 /* Icons
 ----------------------------------*/
 
 /* states and images */
-.ui-icon { display: block; text-indent: -99999px; overflow: hidden; background-repeat: no-repeat; }
+#mc_signup .ui-icon { display: block; text-indent: -99999px; overflow: hidden; background-repeat: no-repeat; }
 
 
 /* Misc visuals
 ----------------------------------*/
 
 /* Overlays */
-.ui-widget-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+#mc_signup .ui-widget-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
 
 
 /*
@@ -56,238 +56,238 @@
 
 /* Component containers
 ----------------------------------*/
-.ui-widget { font-family: Helvetica, Arial, sans-serif; font-size: 1.1em; }
-.ui-widget .ui-widget { font-size: 1em; }
-.ui-widget input, .ui-widget select, .ui-widget textarea, .ui-widget button { font-family: Helvetica, Arial, sans-serif; font-size: 1em; }
-.ui-widget-content { border: 1px solid #dddddd; background: #ffffff url(images/ui-bg_flat_75_ffffff_40x100.png) 50% 50% repeat-x; color: #444444; }
-.ui-widget-content a { color: #444444; }
-.ui-widget-header { border: 1px solid #dddddd; background: #dddddd url(images/ui-bg_highlight-soft_50_dddddd_1x100.png) 50% 50% repeat-x; color: #444444; font-weight: bold; }
-.ui-widget-header a { color: #444444; }
+#mc_signup .ui-widget { font-family: Helvetica, Arial, sans-serif; font-size: 1.1em; }
+#mc_signup .ui-widget .ui-widget { font-size: 1em; }
+#mc_signup .ui-widget input, #mc_signup .ui-widget select, #mc_signup .ui-widget textarea, #mc_signup .ui-widget button { font-family: Helvetica, Arial, sans-serif; font-size: 1em; }
+#mc_signup .ui-widget-content { border: 1px solid #dddddd; background: #ffffff url(images/ui-bg_flat_75_ffffff_40x100.png) 50% 50% repeat-x; color: #444444; }
+#mc_signup .ui-widget-content a { color: #444444; }
+#mc_signup .ui-widget-header { border: 1px solid #dddddd; background: #dddddd url(images/ui-bg_highlight-soft_50_dddddd_1x100.png) 50% 50% repeat-x; color: #444444; font-weight: bold; }
+#mc_signup .ui-widget-header a { color: #444444; }
 
 /* Interaction states
 ----------------------------------*/
-.ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default { border: 1px solid #dddddd; background: #f6f6f6 url(images/ui-bg_highlight-soft_100_f6f6f6_1x100.png) 50% 50% repeat-x; font-weight: bold; color: #0073ea; }
-.ui-state-default a, .ui-state-default a:link, .ui-state-default a:visited { color: #0073ea; text-decoration: none; }
-.ui-state-hover, .ui-widget-content .ui-state-hover, .ui-widget-header .ui-state-hover, .ui-state-focus, .ui-widget-content .ui-state-focus, .ui-widget-header .ui-state-focus { border: 1px solid #0073ea; background: #0073ea url(images/ui-bg_highlight-soft_25_0073ea_1x100.png) 50% 50% repeat-x; font-weight: bold; color: #ffffff; }
-.ui-state-hover a, .ui-state-hover a:hover { color: #ffffff; text-decoration: none; }
-.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active { border: 1px solid #dddddd; background: #ffffff url(images/ui-bg_glass_65_ffffff_1x400.png) 50% 50% repeat-x; font-weight: bold; color: #ff0084; }
-.ui-state-active a, .ui-state-active a:link, .ui-state-active a:visited { color: #ff0084; text-decoration: none; }
-.ui-widget :active { outline: none; }
+#mc_signup .ui-state-default, #mc_signup .ui-widget-content .ui-state-default, #mc_signup .ui-widget-header .ui-state-default { border: 1px solid #dddddd; background: #f6f6f6 url(images/ui-bg_highlight-soft_100_f6f6f6_1x100.png) 50% 50% repeat-x; font-weight: bold; color: #0073ea; }
+#mc_signup .ui-state-default a, #mc_signup .ui-state-default a:link, #mc_signup .ui-state-default a:visited { color: #0073ea; text-decoration: none; }
+#mc_signup .ui-state-hover, #mc_signup .ui-widget-content .ui-state-hover, #mc_signup .ui-widget-header .ui-state-hover, #mc_signup .ui-state-focus, #mc_signup .ui-widget-content .ui-state-focus, #mc_signup .ui-widget-header .ui-state-focus { border: 1px solid #0073ea; background: #0073ea url(images/ui-bg_highlight-soft_25_0073ea_1x100.png) 50% 50% repeat-x; font-weight: bold; color: #ffffff; }
+#mc_signup .ui-state-hover a, #mc_signup .ui-state-hover a:hover { color: #ffffff; text-decoration: none; }
+#mc_signup .ui-state-active, #mc_signup .ui-widget-content .ui-state-active, #mc_signup .ui-widget-header .ui-state-active { border: 1px solid #dddddd; background: #ffffff url(images/ui-bg_glass_65_ffffff_1x400.png) 50% 50% repeat-x; font-weight: bold; color: #ff0084; }
+#mc_signup .ui-state-active a, #mc_signup .ui-state-active a:link, #mc_signup .ui-state-active a:visited { color: #ff0084; text-decoration: none; }
+#mc_signup .ui-widget :active { outline: none; }
 
 /* Interaction Cues
 ----------------------------------*/
-.ui-state-highlight, .ui-widget-content .ui-state-highlight, .ui-widget-header .ui-state-highlight  {border: 1px solid #cccccc; background: #ffffff url(images/ui-bg_flat_55_ffffff_40x100.png) 50% 50% repeat-x; color: #444444; }
-.ui-state-highlight a, .ui-widget-content .ui-state-highlight a,.ui-widget-header .ui-state-highlight a { color: #444444; }
-.ui-state-error, .ui-widget-content .ui-state-error, .ui-widget-header .ui-state-error {border: 1px solid #ff0084; background: #ffffff url(images/ui-bg_flat_55_ffffff_40x100.png) 50% 50% repeat-x; color: #222222; }
-.ui-state-error a, .ui-widget-content .ui-state-error a, .ui-widget-header .ui-state-error a { color: #222222; }
-.ui-state-error-text, .ui-widget-content .ui-state-error-text, .ui-widget-header .ui-state-error-text { color: #222222; }
-.ui-priority-primary, .ui-widget-content .ui-priority-primary, .ui-widget-header .ui-priority-primary { font-weight: bold; }
-.ui-priority-secondary, .ui-widget-content .ui-priority-secondary,  .ui-widget-header .ui-priority-secondary { opacity: .7; filter:Alpha(Opacity=70); font-weight: normal; }
-.ui-state-disabled, .ui-widget-content .ui-state-disabled, .ui-widget-header .ui-state-disabled { opacity: .35; filter:Alpha(Opacity=35); background-image: none; }
+#mc_signup .ui-state-highlight, #mc_signup .ui-widget-content .ui-state-highlight, #mc_signup .ui-widget-header .ui-state-highlight  {border: 1px solid #cccccc; background: #ffffff url(images/ui-bg_flat_55_ffffff_40x100.png) 50% 50% repeat-x; color: #444444; }
+#mc_signup .ui-state-highlight a, #mc_signup .ui-widget-content .ui-state-highlight a, #mc_signup .ui-widget-header .ui-state-highlight a { color: #444444; }
+#mc_signup .ui-state-error, #mc_signup .ui-widget-content .ui-state-error, #mc_signup .ui-widget-header .ui-state-error {border: 1px solid #ff0084; background: #ffffff url(images/ui-bg_flat_55_ffffff_40x100.png) 50% 50% repeat-x; color: #222222; }
+#mc_signup .ui-state-error a, #mc_signup .ui-widget-content .ui-state-error a, #mc_signup .ui-widget-header .ui-state-error a { color: #222222; }
+#mc_signup .ui-state-error-text, #mc_signup .ui-widget-content .ui-state-error-text, #mc_signup .ui-widget-header .ui-state-error-text { color: #222222; }
+#mc_signup .ui-priority-primary, #mc_signup .ui-widget-content .ui-priority-primary, #mc_signup .ui-widget-header .ui-priority-primary { font-weight: bold; }
+#mc_signup .ui-priority-secondary, #mc_signup .ui-widget-content .ui-priority-secondary, #mc_signup .ui-widget-header .ui-priority-secondary { opacity: .7; filter:Alpha(Opacity=70); font-weight: normal; }
+#mc_signup .ui-state-disabled, #mc_signup .ui-widget-content .ui-state-disabled, #mc_signup .ui-widget-header .ui-state-disabled { opacity: .35; filter:Alpha(Opacity=35); background-image: none; }
 
 /* Icons
 ----------------------------------*/
 
 /* states and images */
-.ui-icon { width: 16px; height: 16px; background-image: url(images/ui-icons_ff0084_256x240.png); }
-.ui-widget-content .ui-icon {background-image: url(images/ui-icons_ff0084_256x240.png); }
-.ui-widget-header .ui-icon {background-image: url(images/ui-icons_0073ea_256x240.png); }
-.ui-state-default .ui-icon { background-image: url(images/ui-icons_666666_256x240.png); }
-.ui-state-hover .ui-icon, .ui-state-focus .ui-icon {background-image: url(images/ui-icons_ffffff_256x240.png); }
-.ui-state-active .ui-icon {background-image: url(images/ui-icons_454545_256x240.png); }
-.ui-state-highlight .ui-icon {background-image: url(images/ui-icons_0073ea_256x240.png); }
-.ui-state-error .ui-icon, .ui-state-error-text .ui-icon {background-image: url(images/ui-icons_ff0084_256x240.png); }
+#mc_signup .ui-icon { width: 16px; height: 16px; background-image: url(images/ui-icons_ff0084_256x240.png); }
+#mc_signup .ui-widget-content .ui-icon {background-image: url(images/ui-icons_ff0084_256x240.png); }
+#mc_signup .ui-widget-header .ui-icon {background-image: url(images/ui-icons_0073ea_256x240.png); }
+#mc_signup .ui-state-default .ui-icon { background-image: url(images/ui-icons_666666_256x240.png); }
+#mc_signup .ui-state-hover .ui-icon, #mc_signup .ui-state-focus .ui-icon {background-image: url(images/ui-icons_ffffff_256x240.png); }
+#mc_signup .ui-state-active .ui-icon {background-image: url(images/ui-icons_454545_256x240.png); }
+#mc_signup .ui-state-highlight .ui-icon {background-image: url(images/ui-icons_0073ea_256x240.png); }
+#mc_signup .ui-state-error .ui-icon, #mc_signup .ui-state-error-text .ui-icon {background-image: url(images/ui-icons_ff0084_256x240.png); }
 
 /* positioning */
-.ui-icon-carat-1-n { background-position: 0 0; }
-.ui-icon-carat-1-ne { background-position: -16px 0; }
-.ui-icon-carat-1-e { background-position: -32px 0; }
-.ui-icon-carat-1-se { background-position: -48px 0; }
-.ui-icon-carat-1-s { background-position: -64px 0; }
-.ui-icon-carat-1-sw { background-position: -80px 0; }
-.ui-icon-carat-1-w { background-position: -96px 0; }
-.ui-icon-carat-1-nw { background-position: -112px 0; }
-.ui-icon-carat-2-n-s { background-position: -128px 0; }
-.ui-icon-carat-2-e-w { background-position: -144px 0; }
-.ui-icon-triangle-1-n { background-position: 0 -16px; }
-.ui-icon-triangle-1-ne { background-position: -16px -16px; }
-.ui-icon-triangle-1-e { background-position: -32px -16px; }
-.ui-icon-triangle-1-se { background-position: -48px -16px; }
-.ui-icon-triangle-1-s { background-position: -64px -16px; }
-.ui-icon-triangle-1-sw { background-position: -80px -16px; }
-.ui-icon-triangle-1-w { background-position: -96px -16px; }
-.ui-icon-triangle-1-nw { background-position: -112px -16px; }
-.ui-icon-triangle-2-n-s { background-position: -128px -16px; }
-.ui-icon-triangle-2-e-w { background-position: -144px -16px; }
-.ui-icon-arrow-1-n { background-position: 0 -32px; }
-.ui-icon-arrow-1-ne { background-position: -16px -32px; }
-.ui-icon-arrow-1-e { background-position: -32px -32px; }
-.ui-icon-arrow-1-se { background-position: -48px -32px; }
-.ui-icon-arrow-1-s { background-position: -64px -32px; }
-.ui-icon-arrow-1-sw { background-position: -80px -32px; }
-.ui-icon-arrow-1-w { background-position: -96px -32px; }
-.ui-icon-arrow-1-nw { background-position: -112px -32px; }
-.ui-icon-arrow-2-n-s { background-position: -128px -32px; }
-.ui-icon-arrow-2-ne-sw { background-position: -144px -32px; }
-.ui-icon-arrow-2-e-w { background-position: -160px -32px; }
-.ui-icon-arrow-2-se-nw { background-position: -176px -32px; }
-.ui-icon-arrowstop-1-n { background-position: -192px -32px; }
-.ui-icon-arrowstop-1-e { background-position: -208px -32px; }
-.ui-icon-arrowstop-1-s { background-position: -224px -32px; }
-.ui-icon-arrowstop-1-w { background-position: -240px -32px; }
-.ui-icon-arrowthick-1-n { background-position: 0 -48px; }
-.ui-icon-arrowthick-1-ne { background-position: -16px -48px; }
-.ui-icon-arrowthick-1-e { background-position: -32px -48px; }
-.ui-icon-arrowthick-1-se { background-position: -48px -48px; }
-.ui-icon-arrowthick-1-s { background-position: -64px -48px; }
-.ui-icon-arrowthick-1-sw { background-position: -80px -48px; }
-.ui-icon-arrowthick-1-w { background-position: -96px -48px; }
-.ui-icon-arrowthick-1-nw { background-position: -112px -48px; }
-.ui-icon-arrowthick-2-n-s { background-position: -128px -48px; }
-.ui-icon-arrowthick-2-ne-sw { background-position: -144px -48px; }
-.ui-icon-arrowthick-2-e-w { background-position: -160px -48px; }
-.ui-icon-arrowthick-2-se-nw { background-position: -176px -48px; }
-.ui-icon-arrowthickstop-1-n { background-position: -192px -48px; }
-.ui-icon-arrowthickstop-1-e { background-position: -208px -48px; }
-.ui-icon-arrowthickstop-1-s { background-position: -224px -48px; }
-.ui-icon-arrowthickstop-1-w { background-position: -240px -48px; }
-.ui-icon-arrowreturnthick-1-w { background-position: 0 -64px; }
-.ui-icon-arrowreturnthick-1-n { background-position: -16px -64px; }
-.ui-icon-arrowreturnthick-1-e { background-position: -32px -64px; }
-.ui-icon-arrowreturnthick-1-s { background-position: -48px -64px; }
-.ui-icon-arrowreturn-1-w { background-position: -64px -64px; }
-.ui-icon-arrowreturn-1-n { background-position: -80px -64px; }
-.ui-icon-arrowreturn-1-e { background-position: -96px -64px; }
-.ui-icon-arrowreturn-1-s { background-position: -112px -64px; }
-.ui-icon-arrowrefresh-1-w { background-position: -128px -64px; }
-.ui-icon-arrowrefresh-1-n { background-position: -144px -64px; }
-.ui-icon-arrowrefresh-1-e { background-position: -160px -64px; }
-.ui-icon-arrowrefresh-1-s { background-position: -176px -64px; }
-.ui-icon-arrow-4 { background-position: 0 -80px; }
-.ui-icon-arrow-4-diag { background-position: -16px -80px; }
-.ui-icon-extlink { background-position: -32px -80px; }
-.ui-icon-newwin { background-position: -48px -80px; }
-.ui-icon-refresh { background-position: -64px -80px; }
-.ui-icon-shuffle { background-position: -80px -80px; }
-.ui-icon-transfer-e-w { background-position: -96px -80px; }
-.ui-icon-transferthick-e-w { background-position: -112px -80px; }
-.ui-icon-folder-collapsed { background-position: 0 -96px; }
-.ui-icon-folder-open { background-position: -16px -96px; }
-.ui-icon-document { background-position: -32px -96px; }
-.ui-icon-document-b { background-position: -48px -96px; }
-.ui-icon-note { background-position: -64px -96px; }
-.ui-icon-mail-closed { background-position: -80px -96px; }
-.ui-icon-mail-open { background-position: -96px -96px; }
-.ui-icon-suitcase { background-position: -112px -96px; }
-.ui-icon-comment { background-position: -128px -96px; }
-.ui-icon-person { background-position: -144px -96px; }
-.ui-icon-print { background-position: -160px -96px; }
-.ui-icon-trash { background-position: -176px -96px; }
-.ui-icon-locked { background-position: -192px -96px; }
-.ui-icon-unlocked { background-position: -208px -96px; }
-.ui-icon-bookmark { background-position: -224px -96px; }
-.ui-icon-tag { background-position: -240px -96px; }
-.ui-icon-home { background-position: 0 -112px; }
-.ui-icon-flag { background-position: -16px -112px; }
-.ui-icon-calendar { background-position: -32px -112px; }
-.ui-icon-cart { background-position: -48px -112px; }
-.ui-icon-pencil { background-position: -64px -112px; }
-.ui-icon-clock { background-position: -80px -112px; }
-.ui-icon-disk { background-position: -96px -112px; }
-.ui-icon-calculator { background-position: -112px -112px; }
-.ui-icon-zoomin { background-position: -128px -112px; }
-.ui-icon-zoomout { background-position: -144px -112px; }
-.ui-icon-search { background-position: -160px -112px; }
-.ui-icon-wrench { background-position: -176px -112px; }
-.ui-icon-gear { background-position: -192px -112px; }
-.ui-icon-heart { background-position: -208px -112px; }
-.ui-icon-star { background-position: -224px -112px; }
-.ui-icon-link { background-position: -240px -112px; }
-.ui-icon-cancel { background-position: 0 -128px; }
-.ui-icon-plus { background-position: -16px -128px; }
-.ui-icon-plusthick { background-position: -32px -128px; }
-.ui-icon-minus { background-position: -48px -128px; }
-.ui-icon-minusthick { background-position: -64px -128px; }
-.ui-icon-close { background-position: -80px -128px; }
-.ui-icon-closethick { background-position: -96px -128px; }
-.ui-icon-key { background-position: -112px -128px; }
-.ui-icon-lightbulb { background-position: -128px -128px; }
-.ui-icon-scissors { background-position: -144px -128px; }
-.ui-icon-clipboard { background-position: -160px -128px; }
-.ui-icon-copy { background-position: -176px -128px; }
-.ui-icon-contact { background-position: -192px -128px; }
-.ui-icon-image { background-position: -208px -128px; }
-.ui-icon-video { background-position: -224px -128px; }
-.ui-icon-script { background-position: -240px -128px; }
-.ui-icon-alert { background-position: 0 -144px; }
-.ui-icon-info { background-position: -16px -144px; }
-.ui-icon-notice { background-position: -32px -144px; }
-.ui-icon-help { background-position: -48px -144px; }
-.ui-icon-check { background-position: -64px -144px; }
-.ui-icon-bullet { background-position: -80px -144px; }
-.ui-icon-radio-off { background-position: -96px -144px; }
-.ui-icon-radio-on { background-position: -112px -144px; }
-.ui-icon-pin-w { background-position: -128px -144px; }
-.ui-icon-pin-s { background-position: -144px -144px; }
-.ui-icon-play { background-position: 0 -160px; }
-.ui-icon-pause { background-position: -16px -160px; }
-.ui-icon-seek-next { background-position: -32px -160px; }
-.ui-icon-seek-prev { background-position: -48px -160px; }
-.ui-icon-seek-end { background-position: -64px -160px; }
-.ui-icon-seek-start { background-position: -80px -160px; }
+#mc_signup .ui-icon-carat-1-n { background-position: 0 0; }
+#mc_signup .ui-icon-carat-1-ne { background-position: -16px 0; }
+#mc_signup .ui-icon-carat-1-e { background-position: -32px 0; }
+#mc_signup .ui-icon-carat-1-se { background-position: -48px 0; }
+#mc_signup .ui-icon-carat-1-s { background-position: -64px 0; }
+#mc_signup .ui-icon-carat-1-sw { background-position: -80px 0; }
+#mc_signup .ui-icon-carat-1-w { background-position: -96px 0; }
+#mc_signup .ui-icon-carat-1-nw { background-position: -112px 0; }
+#mc_signup .ui-icon-carat-2-n-s { background-position: -128px 0; }
+#mc_signup .ui-icon-carat-2-e-w { background-position: -144px 0; }
+#mc_signup .ui-icon-triangle-1-n { background-position: 0 -16px; }
+#mc_signup .ui-icon-triangle-1-ne { background-position: -16px -16px; }
+#mc_signup .ui-icon-triangle-1-e { background-position: -32px -16px; }
+#mc_signup .ui-icon-triangle-1-se { background-position: -48px -16px; }
+#mc_signup .ui-icon-triangle-1-s { background-position: -64px -16px; }
+#mc_signup .ui-icon-triangle-1-sw { background-position: -80px -16px; }
+#mc_signup .ui-icon-triangle-1-w { background-position: -96px -16px; }
+#mc_signup .ui-icon-triangle-1-nw { background-position: -112px -16px; }
+#mc_signup .ui-icon-triangle-2-n-s { background-position: -128px -16px; }
+#mc_signup .ui-icon-triangle-2-e-w { background-position: -144px -16px; }
+#mc_signup .ui-icon-arrow-1-n { background-position: 0 -32px; }
+#mc_signup .ui-icon-arrow-1-ne { background-position: -16px -32px; }
+#mc_signup .ui-icon-arrow-1-e { background-position: -32px -32px; }
+#mc_signup .ui-icon-arrow-1-se { background-position: -48px -32px; }
+#mc_signup .ui-icon-arrow-1-s { background-position: -64px -32px; }
+#mc_signup .ui-icon-arrow-1-sw { background-position: -80px -32px; }
+#mc_signup .ui-icon-arrow-1-w { background-position: -96px -32px; }
+#mc_signup .ui-icon-arrow-1-nw { background-position: -112px -32px; }
+#mc_signup .ui-icon-arrow-2-n-s { background-position: -128px -32px; }
+#mc_signup .ui-icon-arrow-2-ne-sw { background-position: -144px -32px; }
+#mc_signup .ui-icon-arrow-2-e-w { background-position: -160px -32px; }
+#mc_signup .ui-icon-arrow-2-se-nw { background-position: -176px -32px; }
+#mc_signup .ui-icon-arrowstop-1-n { background-position: -192px -32px; }
+#mc_signup .ui-icon-arrowstop-1-e { background-position: -208px -32px; }
+#mc_signup .ui-icon-arrowstop-1-s { background-position: -224px -32px; }
+#mc_signup .ui-icon-arrowstop-1-w { background-position: -240px -32px; }
+#mc_signup .ui-icon-arrowthick-1-n { background-position: 0 -48px; }
+#mc_signup .ui-icon-arrowthick-1-ne { background-position: -16px -48px; }
+#mc_signup .ui-icon-arrowthick-1-e { background-position: -32px -48px; }
+#mc_signup .ui-icon-arrowthick-1-se { background-position: -48px -48px; }
+#mc_signup .ui-icon-arrowthick-1-s { background-position: -64px -48px; }
+#mc_signup .ui-icon-arrowthick-1-sw { background-position: -80px -48px; }
+#mc_signup .ui-icon-arrowthick-1-w { background-position: -96px -48px; }
+#mc_signup .ui-icon-arrowthick-1-nw { background-position: -112px -48px; }
+#mc_signup .ui-icon-arrowthick-2-n-s { background-position: -128px -48px; }
+#mc_signup .ui-icon-arrowthick-2-ne-sw { background-position: -144px -48px; }
+#mc_signup .ui-icon-arrowthick-2-e-w { background-position: -160px -48px; }
+#mc_signup .ui-icon-arrowthick-2-se-nw { background-position: -176px -48px; }
+#mc_signup .ui-icon-arrowthickstop-1-n { background-position: -192px -48px; }
+#mc_signup .ui-icon-arrowthickstop-1-e { background-position: -208px -48px; }
+#mc_signup .ui-icon-arrowthickstop-1-s { background-position: -224px -48px; }
+#mc_signup .ui-icon-arrowthickstop-1-w { background-position: -240px -48px; }
+#mc_signup .ui-icon-arrowreturnthick-1-w { background-position: 0 -64px; }
+#mc_signup .ui-icon-arrowreturnthick-1-n { background-position: -16px -64px; }
+#mc_signup .ui-icon-arrowreturnthick-1-e { background-position: -32px -64px; }
+#mc_signup .ui-icon-arrowreturnthick-1-s { background-position: -48px -64px; }
+#mc_signup .ui-icon-arrowreturn-1-w { background-position: -64px -64px; }
+#mc_signup .ui-icon-arrowreturn-1-n { background-position: -80px -64px; }
+#mc_signup .ui-icon-arrowreturn-1-e { background-position: -96px -64px; }
+#mc_signup .ui-icon-arrowreturn-1-s { background-position: -112px -64px; }
+#mc_signup .ui-icon-arrowrefresh-1-w { background-position: -128px -64px; }
+#mc_signup .ui-icon-arrowrefresh-1-n { background-position: -144px -64px; }
+#mc_signup .ui-icon-arrowrefresh-1-e { background-position: -160px -64px; }
+#mc_signup .ui-icon-arrowrefresh-1-s { background-position: -176px -64px; }
+#mc_signup .ui-icon-arrow-4 { background-position: 0 -80px; }
+#mc_signup .ui-icon-arrow-4-diag { background-position: -16px -80px; }
+#mc_signup .ui-icon-extlink { background-position: -32px -80px; }
+#mc_signup .ui-icon-newwin { background-position: -48px -80px; }
+#mc_signup .ui-icon-refresh { background-position: -64px -80px; }
+#mc_signup .ui-icon-shuffle { background-position: -80px -80px; }
+#mc_signup .ui-icon-transfer-e-w { background-position: -96px -80px; }
+#mc_signup .ui-icon-transferthick-e-w { background-position: -112px -80px; }
+#mc_signup .ui-icon-folder-collapsed { background-position: 0 -96px; }
+#mc_signup .ui-icon-folder-open { background-position: -16px -96px; }
+#mc_signup .ui-icon-document { background-position: -32px -96px; }
+#mc_signup .ui-icon-document-b { background-position: -48px -96px; }
+#mc_signup .ui-icon-note { background-position: -64px -96px; }
+#mc_signup .ui-icon-mail-closed { background-position: -80px -96px; }
+#mc_signup .ui-icon-mail-open { background-position: -96px -96px; }
+#mc_signup .ui-icon-suitcase { background-position: -112px -96px; }
+#mc_signup .ui-icon-comment { background-position: -128px -96px; }
+#mc_signup .ui-icon-person { background-position: -144px -96px; }
+#mc_signup .ui-icon-print { background-position: -160px -96px; }
+#mc_signup .ui-icon-trash { background-position: -176px -96px; }
+#mc_signup .ui-icon-locked { background-position: -192px -96px; }
+#mc_signup .ui-icon-unlocked { background-position: -208px -96px; }
+#mc_signup .ui-icon-bookmark { background-position: -224px -96px; }
+#mc_signup .ui-icon-tag { background-position: -240px -96px; }
+#mc_signup .ui-icon-home { background-position: 0 -112px; }
+#mc_signup .ui-icon-flag { background-position: -16px -112px; }
+#mc_signup .ui-icon-calendar { background-position: -32px -112px; }
+#mc_signup .ui-icon-cart { background-position: -48px -112px; }
+#mc_signup .ui-icon-pencil { background-position: -64px -112px; }
+#mc_signup .ui-icon-clock { background-position: -80px -112px; }
+#mc_signup .ui-icon-disk { background-position: -96px -112px; }
+#mc_signup .ui-icon-calculator { background-position: -112px -112px; }
+#mc_signup .ui-icon-zoomin { background-position: -128px -112px; }
+#mc_signup .ui-icon-zoomout { background-position: -144px -112px; }
+#mc_signup .ui-icon-search { background-position: -160px -112px; }
+#mc_signup .ui-icon-wrench { background-position: -176px -112px; }
+#mc_signup .ui-icon-gear { background-position: -192px -112px; }
+#mc_signup .ui-icon-heart { background-position: -208px -112px; }
+#mc_signup .ui-icon-star { background-position: -224px -112px; }
+#mc_signup .ui-icon-link { background-position: -240px -112px; }
+#mc_signup .ui-icon-cancel { background-position: 0 -128px; }
+#mc_signup .ui-icon-plus { background-position: -16px -128px; }
+#mc_signup .ui-icon-plusthick { background-position: -32px -128px; }
+#mc_signup .ui-icon-minus { background-position: -48px -128px; }
+#mc_signup .ui-icon-minusthick { background-position: -64px -128px; }
+#mc_signup .ui-icon-close { background-position: -80px -128px; }
+#mc_signup .ui-icon-closethick { background-position: -96px -128px; }
+#mc_signup .ui-icon-key { background-position: -112px -128px; }
+#mc_signup .ui-icon-lightbulb { background-position: -128px -128px; }
+#mc_signup .ui-icon-scissors { background-position: -144px -128px; }
+#mc_signup .ui-icon-clipboard { background-position: -160px -128px; }
+#mc_signup .ui-icon-copy { background-position: -176px -128px; }
+#mc_signup .ui-icon-contact { background-position: -192px -128px; }
+#mc_signup .ui-icon-image { background-position: -208px -128px; }
+#mc_signup .ui-icon-video { background-position: -224px -128px; }
+#mc_signup .ui-icon-script { background-position: -240px -128px; }
+#mc_signup .ui-icon-alert { background-position: 0 -144px; }
+#mc_signup .ui-icon-info { background-position: -16px -144px; }
+#mc_signup .ui-icon-notice { background-position: -32px -144px; }
+#mc_signup .ui-icon-help { background-position: -48px -144px; }
+#mc_signup .ui-icon-check { background-position: -64px -144px; }
+#mc_signup .ui-icon-bullet { background-position: -80px -144px; }
+#mc_signup .ui-icon-radio-off { background-position: -96px -144px; }
+#mc_signup .ui-icon-radio-on { background-position: -112px -144px; }
+#mc_signup .ui-icon-pin-w { background-position: -128px -144px; }
+#mc_signup .ui-icon-pin-s { background-position: -144px -144px; }
+#mc_signup .ui-icon-play { background-position: 0 -160px; }
+#mc_signup .ui-icon-pause { background-position: -16px -160px; }
+#mc_signup .ui-icon-seek-next { background-position: -32px -160px; }
+#mc_signup .ui-icon-seek-prev { background-position: -48px -160px; }
+#mc_signup .ui-icon-seek-end { background-position: -64px -160px; }
+#mc_signup .ui-icon-seek-start { background-position: -80px -160px; }
 /* ui-icon-seek-first is deprecated, use ui-icon-seek-start instead */
-.ui-icon-seek-first { background-position: -80px -160px; }
-.ui-icon-stop { background-position: -96px -160px; }
-.ui-icon-eject { background-position: -112px -160px; }
-.ui-icon-volume-off { background-position: -128px -160px; }
-.ui-icon-volume-on { background-position: -144px -160px; }
-.ui-icon-power { background-position: 0 -176px; }
-.ui-icon-signal-diag { background-position: -16px -176px; }
-.ui-icon-signal { background-position: -32px -176px; }
-.ui-icon-battery-0 { background-position: -48px -176px; }
-.ui-icon-battery-1 { background-position: -64px -176px; }
-.ui-icon-battery-2 { background-position: -80px -176px; }
-.ui-icon-battery-3 { background-position: -96px -176px; }
-.ui-icon-circle-plus { background-position: 0 -192px; }
-.ui-icon-circle-minus { background-position: -16px -192px; }
-.ui-icon-circle-close { background-position: -32px -192px; }
-.ui-icon-circle-triangle-e { background-position: -48px -192px; }
-.ui-icon-circle-triangle-s { background-position: -64px -192px; }
-.ui-icon-circle-triangle-w { background-position: -80px -192px; }
-.ui-icon-circle-triangle-n { background-position: -96px -192px; }
-.ui-icon-circle-arrow-e { background-position: -112px -192px; }
-.ui-icon-circle-arrow-s { background-position: -128px -192px; }
-.ui-icon-circle-arrow-w { background-position: -144px -192px; }
-.ui-icon-circle-arrow-n { background-position: -160px -192px; }
-.ui-icon-circle-zoomin { background-position: -176px -192px; }
-.ui-icon-circle-zoomout { background-position: -192px -192px; }
-.ui-icon-circle-check { background-position: -208px -192px; }
-.ui-icon-circlesmall-plus { background-position: 0 -208px; }
-.ui-icon-circlesmall-minus { background-position: -16px -208px; }
-.ui-icon-circlesmall-close { background-position: -32px -208px; }
-.ui-icon-squaresmall-plus { background-position: -48px -208px; }
-.ui-icon-squaresmall-minus { background-position: -64px -208px; }
-.ui-icon-squaresmall-close { background-position: -80px -208px; }
-.ui-icon-grip-dotted-vertical { background-position: 0 -224px; }
-.ui-icon-grip-dotted-horizontal { background-position: -16px -224px; }
-.ui-icon-grip-solid-vertical { background-position: -32px -224px; }
-.ui-icon-grip-solid-horizontal { background-position: -48px -224px; }
-.ui-icon-gripsmall-diagonal-se { background-position: -64px -224px; }
-.ui-icon-grip-diagonal-se { background-position: -80px -224px; }
+#mc_signup .ui-icon-seek-first { background-position: -80px -160px; }
+#mc_signup .ui-icon-stop { background-position: -96px -160px; }
+#mc_signup .ui-icon-eject { background-position: -112px -160px; }
+#mc_signup .ui-icon-volume-off { background-position: -128px -160px; }
+#mc_signup .ui-icon-volume-on { background-position: -144px -160px; }
+#mc_signup .ui-icon-power { background-position: 0 -176px; }
+#mc_signup .ui-icon-signal-diag { background-position: -16px -176px; }
+#mc_signup .ui-icon-signal { background-position: -32px -176px; }
+#mc_signup .ui-icon-battery-0 { background-position: -48px -176px; }
+#mc_signup .ui-icon-battery-1 { background-position: -64px -176px; }
+#mc_signup .ui-icon-battery-2 { background-position: -80px -176px; }
+#mc_signup .ui-icon-battery-3 { background-position: -96px -176px; }
+#mc_signup .ui-icon-circle-plus { background-position: 0 -192px; }
+#mc_signup .ui-icon-circle-minus { background-position: -16px -192px; }
+#mc_signup .ui-icon-circle-close { background-position: -32px -192px; }
+#mc_signup .ui-icon-circle-triangle-e { background-position: -48px -192px; }
+#mc_signup .ui-icon-circle-triangle-s { background-position: -64px -192px; }
+#mc_signup .ui-icon-circle-triangle-w { background-position: -80px -192px; }
+#mc_signup .ui-icon-circle-triangle-n { background-position: -96px -192px; }
+#mc_signup .ui-icon-circle-arrow-e { background-position: -112px -192px; }
+#mc_signup .ui-icon-circle-arrow-s { background-position: -128px -192px; }
+#mc_signup .ui-icon-circle-arrow-w { background-position: -144px -192px; }
+#mc_signup .ui-icon-circle-arrow-n { background-position: -160px -192px; }
+#mc_signup .ui-icon-circle-zoomin { background-position: -176px -192px; }
+#mc_signup .ui-icon-circle-zoomout { background-position: -192px -192px; }
+#mc_signup .ui-icon-circle-check { background-position: -208px -192px; }
+#mc_signup .ui-icon-circlesmall-plus { background-position: 0 -208px; }
+#mc_signup .ui-icon-circlesmall-minus { background-position: -16px -208px; }
+#mc_signup .ui-icon-circlesmall-close { background-position: -32px -208px; }
+#mc_signup .ui-icon-squaresmall-plus { background-position: -48px -208px; }
+#mc_signup .ui-icon-squaresmall-minus { background-position: -64px -208px; }
+#mc_signup .ui-icon-squaresmall-close { background-position: -80px -208px; }
+#mc_signup .ui-icon-grip-dotted-vertical { background-position: 0 -224px; }
+#mc_signup .ui-icon-grip-dotted-horizontal { background-position: -16px -224px; }
+#mc_signup .ui-icon-grip-solid-vertical { background-position: -32px -224px; }
+#mc_signup .ui-icon-grip-solid-horizontal { background-position: -48px -224px; }
+#mc_signup .ui-icon-gripsmall-diagonal-se { background-position: -64px -224px; }
+#mc_signup .ui-icon-grip-diagonal-se { background-position: -80px -224px; }
 
 
 /* Misc visuals
 ----------------------------------*/
 
 /* Corner radius */
-.ui-corner-all, .ui-corner-top, .ui-corner-left, .ui-corner-tl { -moz-border-radius-topleft: 2px; -webkit-border-top-left-radius: 2px; -khtml-border-top-left-radius: 2px; border-top-left-radius: 2px; }
-.ui-corner-all, .ui-corner-top, .ui-corner-right, .ui-corner-tr { -moz-border-radius-topright: 2px; -webkit-border-top-right-radius: 2px; -khtml-border-top-right-radius: 2px; border-top-right-radius: 2px; }
-.ui-corner-all, .ui-corner-bottom, .ui-corner-left, .ui-corner-bl { -moz-border-radius-bottomleft: 2px; -webkit-border-bottom-left-radius: 2px; -khtml-border-bottom-left-radius: 2px; border-bottom-left-radius: 2px; }
-.ui-corner-all, .ui-corner-bottom, .ui-corner-right, .ui-corner-br { -moz-border-radius-bottomright: 2px; -webkit-border-bottom-right-radius: 2px; -khtml-border-bottom-right-radius: 2px; border-bottom-right-radius: 2px; }
+#mc_signup .ui-corner-all, #mc_signup .ui-corner-top, #mc_signup .ui-corner-left, #mc_signup .ui-corner-tl { -moz-border-radius-topleft: 2px; -webkit-border-top-left-radius: 2px; -khtml-border-top-left-radius: 2px; border-top-left-radius: 2px; }
+#mc_signup .ui-corner-all, #mc_signup .ui-corner-top, #mc_signup .ui-corner-right, #mc_signup .ui-corner-tr { -moz-border-radius-topright: 2px; -webkit-border-top-right-radius: 2px; -khtml-border-top-right-radius: 2px; border-top-right-radius: 2px; }
+#mc_signup .ui-corner-all, #mc_signup .ui-corner-bottom, #mc_signup .ui-corner-left, #mc_signup .ui-corner-bl { -moz-border-radius-bottomleft: 2px; -webkit-border-bottom-left-radius: 2px; -khtml-border-bottom-left-radius: 2px; border-bottom-left-radius: 2px; }
+#mc_signup .ui-corner-all, #mc_signup .ui-corner-bottom, #mc_signup .ui-corner-right, #mc_signup .ui-corner-br { -moz-border-radius-bottomright: 2px; -webkit-border-bottom-right-radius: 2px; -khtml-border-bottom-right-radius: 2px; border-bottom-right-radius: 2px; }
 
 /* Overlays */
-.ui-widget-overlay { background: #eeeeee url(images/ui-bg_flat_0_eeeeee_40x100.png) 50% 50% repeat-x; opacity: .80;filter:Alpha(Opacity=80); }
-.ui-widget-shadow { margin: -4px 0 0 -4px; padding: 4px; background: #aaaaaa url(images/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x; opacity: .60;filter:Alpha(Opacity=60); -moz-border-radius: 0px; -khtml-border-radius: 0px; -webkit-border-radius: 0px; border-radius: 0px; }/*
+#mc_signup .ui-widget-overlay { background: #eeeeee url(images/ui-bg_flat_0_eeeeee_40x100.png) 50% 50% repeat-x; opacity: .80;filter:Alpha(Opacity=80); }
+#mc_signup .ui-widget-shadow { margin: -4px 0 0 -4px; padding: 4px; background: #aaaaaa url(images/ui-bg_flat_0_aaaaaa_40x100.png) 50% 50% repeat-x; opacity: .60;filter:Alpha(Opacity=60); -moz-border-radius: 0px; -khtml-border-radius: 0px; -webkit-border-radius: 0px; border-radius: 0px; }/*
  * jQuery UI Datepicker 1.8.14
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)
@@ -296,55 +296,55 @@
  *
  * http://docs.jquery.com/UI/Datepicker#theming
  */
-.ui-datepicker { width: 17em; padding: .2em .2em 0; display: none; }
-.ui-datepicker .ui-datepicker-header { position:relative; padding:.2em 0; }
-.ui-datepicker .ui-datepicker-prev, .ui-datepicker .ui-datepicker-next { position:absolute; top: 2px; width: 1.8em; height: 1.8em; }
-.ui-datepicker .ui-datepicker-prev-hover, .ui-datepicker .ui-datepicker-next-hover { top: 1px; }
-.ui-datepicker .ui-datepicker-prev { left:2px; }
-.ui-datepicker .ui-datepicker-next { right:2px; }
-.ui-datepicker .ui-datepicker-prev-hover { left:1px; }
-.ui-datepicker .ui-datepicker-next-hover { right:1px; }
-.ui-datepicker .ui-datepicker-prev span, .ui-datepicker .ui-datepicker-next span { display: block; position: absolute; left: 50%; margin-left: -8px; top: 50%; margin-top: -8px;  }
-.ui-datepicker .ui-datepicker-title { margin: 0 2.3em; line-height: 1.8em; text-align: center; }
-.ui-datepicker .ui-datepicker-title select { font-size:1em; margin:1px 0; }
-.ui-datepicker select.ui-datepicker-month-year {width: 100%;}
-.ui-datepicker select.ui-datepicker-month, 
-.ui-datepicker select.ui-datepicker-year { width: 49%;}
-.ui-datepicker table {width: 100%; font-size: .9em; border-collapse: collapse; margin:0 0 .4em; }
-.ui-datepicker th { padding: .7em .3em; text-align: center; font-weight: bold; border: 0;  }
-.ui-datepicker td { border: 0; padding: 1px; }
-.ui-datepicker td span, .ui-datepicker td a { display: block; padding: .2em; text-align: right; text-decoration: none; }
-.ui-datepicker .ui-datepicker-buttonpane { background-image: none; margin: .7em 0 0 0; padding:0 .2em; border-left: 0; border-right: 0; border-bottom: 0; }
-.ui-datepicker .ui-datepicker-buttonpane button { float: right; margin: .5em .2em .4em; cursor: pointer; padding: .2em .6em .3em .6em; width:auto; overflow:visible; }
-.ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current { float:left; }
+#mc_signup .ui-datepicker { width: 17em; padding: .2em .2em 0; display: none; }
+#mc_signup .ui-datepicker .ui-datepicker-header { position:relative; padding:.2em 0; }
+#mc_signup .ui-datepicker .ui-datepicker-prev, #mc_signup .ui-datepicker .ui-datepicker-next { position:absolute; top: 2px; width: 1.8em; height: 1.8em; }
+#mc_signup .ui-datepicker .ui-datepicker-prev-hover, #mc_signup .ui-datepicker .ui-datepicker-next-hover { top: 1px; }
+#mc_signup .ui-datepicker .ui-datepicker-prev { left:2px; }
+#mc_signup .ui-datepicker .ui-datepicker-next { right:2px; }
+#mc_signup .ui-datepicker .ui-datepicker-prev-hover { left:1px; }
+#mc_signup .ui-datepicker .ui-datepicker-next-hover { right:1px; }
+#mc_signup .ui-datepicker .ui-datepicker-prev span, #mc_signup .ui-datepicker .ui-datepicker-next span { display: block; position: absolute; left: 50%; margin-left: -8px; top: 50%; margin-top: -8px;  }
+#mc_signup .ui-datepicker .ui-datepicker-title { margin: 0 2.3em; line-height: 1.8em; text-align: center; }
+#mc_signup .ui-datepicker .ui-datepicker-title select { font-size:1em; margin:1px 0; }
+#mc_signup .ui-datepicker select.ui-datepicker-month-year {width: 100%;}
+#mc_signup .ui-datepicker select.ui-datepicker-month, 
+#mc_signup .ui-datepicker select.ui-datepicker-year { width: 49%;}
+#mc_signup .ui-datepicker table {width: 100%; font-size: .9em; border-collapse: collapse; margin:0 0 .4em; }
+#mc_signup .ui-datepicker th { padding: .7em .3em; text-align: center; font-weight: bold; border: 0;  }
+#mc_signup .ui-datepicker td { border: 0; padding: 1px; }
+#mc_signup .ui-datepicker td span, #mc_signup .ui-datepicker td a { display: block; padding: .2em; text-align: right; text-decoration: none; }
+#mc_signup .ui-datepicker .ui-datepicker-buttonpane { background-image: none; margin: .7em 0 0 0; padding:0 .2em; border-left: 0; border-right: 0; border-bottom: 0; }
+#mc_signup .ui-datepicker .ui-datepicker-buttonpane button { float: right; margin: .5em .2em .4em; cursor: pointer; padding: .2em .6em .3em .6em; width:auto; overflow:visible; }
+#mc_signup .ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current { float:left; }
 
 /* with multiple calendars */
-.ui-datepicker.ui-datepicker-multi { width:auto; }
-.ui-datepicker-multi .ui-datepicker-group { float:left; }
-.ui-datepicker-multi .ui-datepicker-group table { width:95%; margin:0 auto .4em; }
-.ui-datepicker-multi-2 .ui-datepicker-group { width:50%; }
-.ui-datepicker-multi-3 .ui-datepicker-group { width:33.3%; }
-.ui-datepicker-multi-4 .ui-datepicker-group { width:25%; }
-.ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header { border-left-width:0; }
-.ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header { border-left-width:0; }
-.ui-datepicker-multi .ui-datepicker-buttonpane { clear:left; }
-.ui-datepicker-row-break { clear:both; width:100%; font-size:0em; }
+#mc_signup .ui-datepicker.ui-datepicker-multi { width:auto; }
+#mc_signup .ui-datepicker-multi .ui-datepicker-group { float:left; }
+#mc_signup .ui-datepicker-multi .ui-datepicker-group table { width:95%; margin:0 auto .4em; }
+#mc_signup .ui-datepicker-multi-2 .ui-datepicker-group { width:50%; }
+#mc_signup .ui-datepicker-multi-3 .ui-datepicker-group { width:33.3%; }
+#mc_signup .ui-datepicker-multi-4 .ui-datepicker-group { width:25%; }
+#mc_signup .ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header { border-left-width:0; }
+#mc_signup .ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header { border-left-width:0; }
+#mc_signup .ui-datepicker-multi .ui-datepicker-buttonpane { clear:left; }
+#mc_signup .ui-datepicker-row-break { clear:both; width:100%; font-size:0em; }
 
 /* RTL support */
-.ui-datepicker-rtl { direction: rtl; }
-.ui-datepicker-rtl .ui-datepicker-prev { right: 2px; left: auto; }
-.ui-datepicker-rtl .ui-datepicker-next { left: 2px; right: auto; }
-.ui-datepicker-rtl .ui-datepicker-prev:hover { right: 1px; left: auto; }
-.ui-datepicker-rtl .ui-datepicker-next:hover { left: 1px; right: auto; }
-.ui-datepicker-rtl .ui-datepicker-buttonpane { clear:right; }
-.ui-datepicker-rtl .ui-datepicker-buttonpane button { float: left; }
-.ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current { float:right; }
-.ui-datepicker-rtl .ui-datepicker-group { float:right; }
-.ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header { border-right-width:0; border-left-width:1px; }
-.ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header { border-right-width:0; border-left-width:1px; }
+#mc_signup .ui-datepicker-rtl { direction: rtl; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-prev { right: 2px; left: auto; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-next { left: 2px; right: auto; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-prev:hover { right: 1px; left: auto; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-next:hover { left: 1px; right: auto; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-buttonpane { clear:right; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-buttonpane button { float: left; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current { float:right; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-group { float:right; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header { border-right-width:0; border-left-width:1px; }
+#mc_signup .ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header { border-right-width:0; border-left-width:1px; }
 
 /* IE6 IFRAME FIX (taken from datepicker 1.5.3 */
-.ui-datepicker-cover {
+#mc_signup .ui-datepicker-cover {
     display: none; /*sorry for IE5*/
     display/**/: block; /*sorry for IE5*/
     position: absolute; /*must have*/


### PR DESCRIPTION
this patch just adds #mc_signup in front of all the jQuery UI styles in order to avoid clashes with different jQuery UI styles used in other plugins, in themes or elsewhere in WordPress code
