### PR TITLE
Preferred format translation strings

### DIFF
--- a/po/mailchimp.pot
+++ b/po/mailchimp.pot
@@ -363,3 +363,20 @@ msgstr ""
 #: mailchimp.php:620
 msgid "Options"
 msgstr ""
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:140
+msgid "Preferred Format"
+msgstr ""
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:143
+msgid "HTML"
+msgstr ""
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:144
+msgid "Text"
+msgstr ""
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:145
+msgid "Mobile"
+msgstr ""
+

--- a/po/mailchimp_i18n-de_DE.po
+++ b/po/mailchimp_i18n-de_DE.po
@@ -344,3 +344,19 @@ msgstr "Input Type"
 msgid "Options"
 msgstr "Optionen"
 
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:140
+msgid "Preferred Format"
+msgstr "Bevorzugtes Format"
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:143
+msgid "HTML"
+msgstr "HTML"
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:144
+msgid "Text"
+msgstr "Text"
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:145
+msgid "Mobile"
+msgstr "Mobil"
+

--- a/po/mailchimp_i18n-it_IT.po
+++ b/po/mailchimp_i18n-it_IT.po
@@ -342,3 +342,19 @@ msgstr "Input Type"
 msgid "Options"
 msgstr "Opzioni"
 
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:140
+msgid "Preferred Format"
+msgstr "Formato preferito"
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:143
+msgid "HTML"
+msgstr "HTML"
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:144
+msgid "Text"
+msgstr "Testo"
+
+#: wp-content/plugins/mailchimp/mailchimp_widget.php:145
+msgid "Mobile"
+msgstr "Mobile"
+


### PR DESCRIPTION
The preferred format form options do not update from the MailChimp form translations. This change adds the text strings to the translation files.
