### PR TITLE
Adds qtranslate support

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -1250,6 +1250,11 @@ function mailchimpSF_signup_submit() {
 		}
 	}
 
+  if ( defined('QTRANS_INIT') && function_exists('qtrans_getLanguage') ) {
+    $lang = qtrans_getLanguage();
+    $merge['MC_LANGUAGE'] = $lang;
+  }
+    
 	// If we're good
 	if ($success) {
 		// Clear out empty merge vars


### PR DESCRIPTION
if QTRANS_INIT is defined and the function qtrans_getLanguage() exists adds a MC_LANGUAGE merge var to populate language preference

``` php
  if ( defined('QTRANS_INIT') && function_exists('qtrans_getLanguage') ) {
    $lang = qtrans_getLanguage();
    $merge['MC_LANGUAGE'] = $lang;
  }
```
