### PR TITLE
fixed variable naming bug

### DIFF
--- a/mailchimp_widget.php
+++ b/mailchimp_widget.php
@@ -270,7 +270,7 @@ function mailchimpSF_signup_form($args = array()) {
 	</form><!-- /mc_signup_form -->
 </div><!-- /mc_signup_container -->
 	<?php
-	if (!empty($before_widget)) {
+	if (!empty($after_widget)) {
 		echo $after_widget;
 	}
 }


### PR DESCRIPTION
this would have either output an empty $after_widget var if $before_widget is designed 
OR
it would have ignored the set $after_widget var if the $before_widget var is unset.
