### PR TITLE
Fixes #22, CSS datepicker conflict

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -269,7 +269,7 @@ if (get_option('mc_custom_style')=='on'){
 	ul.mc_list li {
 		font-size: 12px;
 	}
-	.ui-datepicker-year {
+	#ui-datepicker-div .ui-datepicker-year {
 		display: none;
 	}
 	#ui-datepicker-div.show .ui-datepicker-year {


### PR DESCRIPTION
Fixes #22, CSS datepicker conflict

Setting .iu-datepicker-year to display: none hides the year dropmenu in all instances of the jQuery UI datepicker. Appending "#ui-datepicker-div" hides the year dropmenu only in the datepicker instance within this plugin.
