### PR TITLE
Fix PHP Warning for undefined index

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -1375,7 +1375,7 @@ function mailchimpSF_signup_submit() {
 		// Custom validation based on type
 		if (is_array($merge) && !empty($merge)) {
 			foreach ($merge as $merge_key => $merge_value) {
-				if ($merge_key !== 'GROUPINGS') {
+				if ($merge_key !== 'GROUPINGS' && isset($mv_tag_keys[$merge_key])) {
 					switch ($mv_tag_keys[$merge_key]['field_type']) {
 						case 'phone':
 							if ($mv_tag_keys[$merge_key]['phoneformat'] == 'US') {


### PR DESCRIPTION
I was receiving the following PHP warning when submitting the signup notice: `Notice: Undefined index: MMERGE4 in /root/wp-content/plugins/mailchimp/mailchimp.php on line 13791`. I'm not sure what the root cause was but this prevents the PHP warnings from happening.