### PR TITLE
Adds hooks for adding content before and after the form

### DIFF
--- a/mailchimp_widget.php
+++ b/mailchimp_widget.php
@@ -130,6 +130,7 @@ function mailchimpSF_signup_form($args = array()) {
 <?php endif; ?>
 
 <div id="mc_signup">
+        <?php do_action('mailchimp_widget_before_form'); ?>
 	<form method="post" action="#mc_signup" id="mc_signup_form">
 		<input type="hidden" id="mc_submit_type" name="mc_submit_type" value="html" />
 		<input type="hidden" name="mcsf_action" value="mc_submit_signup_form" />
@@ -273,6 +274,7 @@ function mailchimpSF_signup_form($args = array()) {
 		
 	</div><!-- /mc_form_inside -->
 	</form><!-- /mc_signup_form -->
+        <?php do_action('mailchimp_widget_after_form'); ?>
 </div><!-- /mc_signup_container -->
 	<?php
 	if (!empty($after_widget)) {


### PR DESCRIPTION
For example I was looking to add some `<small>` detail after the form
![screenshot 2016-03-04 at 15 59 10](https://cloud.githubusercontent.com/assets/472589/13532224/325d8b80-e222-11e5-96ef-7f101e7081e4.png)

Then sometimes to secure that signup you need a seductive image
![Loop](http://g.recordit.co/RLbPATIs3r.gif)
